### PR TITLE
Add link to VS Code Marketplace

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -178,6 +178,18 @@ function App() {
                   <path fillRule="evenodd" d="M6.194 12.753a.75.75 0 001.06.053L16.5 4.44v2.81a.75.75 0 001.5 0v-4.5a.75.75 0 00-.75-.75h-4.5a.75.75 0 000 1.5h2.553l-9.056 8.194a.75.75 0 00-.053 1.06z" clipRule="evenodd" />
                 </svg>
               </a>
+              <a
+                href={`https://marketplace.visualstudio.com/items?itemName=${stats.publisherName}.${stats.extensionName}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sm text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1"
+              >
+                <span>View Extension</span>
+                <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                  <path fillRule="evenodd" d="M4.25 5.5a.75.75 0 00-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 00.75-.75v-4a.75.75 0 011.5 0v4A2.25 2.25 0 0112.75 17h-8.5A2.25 2.25 0 012 14.75v-8.5A2.25 2.25 0 014.25 4h5a.75.75 0 010 1.5h-5z" clipRule="evenodd" />
+                  <path fillRule="evenodd" d="M6.194 12.753a.75.75 0 001.06.053L16.5 4.44v2.81a.75.75 0 001.5 0v-4.5a.75.75 0 00-.75-.75h-4.5a.75.75 0 000 1.5h2.553l-9.056 8.194a.75.75 0 00-.053 1.06z" clipRule="evenodd" />
+                </svg>
+              </a>
             </div>
           </div>
           {extensions.length > 0 && (


### PR DESCRIPTION
## Summary
- add `View Extension` link to open the selected extension in the marketplace

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68699da88098832db5e21d7012065e99